### PR TITLE
支持 macOS 钥匙串读取 DeepSeek Key

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -20,17 +20,22 @@ or a global switch to DeepSeek. Complete the three steps below.
 
 ### 1. Set the DeepSeek API key
 
-Create a key in DeepSeek and store it as the `DEEPSEEK_API_KEY` environment
-variable. Never paste the key into a Codex chat, Issue, screenshot, or repository.
+Create a key in DeepSeek and store it according to your operating system. Never
+paste the key into a Codex chat, Issue, screenshot, or repository.
 
 - Windows: search System Settings for “environment variables” and add
   `DEEPSEEK_API_KEY` under user variables. An already-running Codex Desktop can
   read this user-scoped value.
-- macOS / Linux: set `DEEPSEEK_API_KEY` in the shell or secret manager that will
-  launch Codex, then start Codex.
+- macOS: create a Keychain Access password item whose name is
+  `com.example.codex.deepseek`, whose account is the current macOS username, and
+  whose password is the DeepSeek API key. The installed macOS agent reads it
+  from Keychain whenever Codex needs a token; no LaunchAgent or
+  `launchctl setenv` injection is required.
+- Linux: set `DEEPSEEK_API_KEY` in the shell or secret manager that will launch
+  Codex, then start Codex.
 
-If you do not know how, ask Codex to explain environment-variable setup for your
-operating system without giving it the key itself. See [SECURITY.md](SECURITY.md).
+If you do not know how, ask Codex to explain secret storage for your operating
+system without giving it the key itself. See [SECURITY.md](SECURITY.md).
 
 ### 2. Paste this into Codex
 
@@ -95,8 +100,9 @@ reviewing and trusting the Hook through `/hooks`. See
 - **The child says no task arrived:** the Hook is usually untrusted, the current
   task predates installation, or the Hook did not load. Check `/hooks`, then
   start a new task. Do not switch to inherited turns.
-- **`DEEPSEEK_API_KEY` is missing:** check only whether the environment variable
-  exists; never paste its value into chat.
+- **The key is missing:** on macOS, check the Keychain item name and account; on
+  Windows/Linux, check only whether `DEEPSEEK_API_KEY` exists. Never paste its
+  value into chat.
 - **The installer asks to switch the global provider, start another CLI, or
   install MCP:** stop. That is not this repository's route.
 
@@ -124,8 +130,9 @@ the provider request, and the callback, and it also helps later users.
   [SECURITY.md](SECURITY.md)
 
 The Windows Desktop route has passed a live smoke. The Python 3 protocol passes
-on Windows and Linux/WSL. macOS uses the same POSIX implementation but is not
-yet in the physical-host baseline; real macOS Issue and PR evidence is welcome.
+on Windows and Linux/WSL. macOS uses the same POSIX Hook implementation, and the
+Keychain agent template has structural validation; real macOS provider-smoke
+Issue and PR evidence is still welcome.
 
 ## Cost and affiliation
 

--- a/README.md
+++ b/README.md
@@ -17,16 +17,20 @@ DeepSeek 是本仓库提供的开箱即用实现，不是这种组合的能力�
 
 ### 1. 设置 DeepSeek API key
 
-在 DeepSeek 创建 key，然后把它保存为环境变量 `DEEPSEEK_API_KEY`。不要把 key
-发进 Codex 聊天、Issue、截图或仓库。
+在 DeepSeek 创建 key，然后按系统保存。不要把 key 发进 Codex 聊天、Issue、截图
+或仓库。
 
 - Windows：在系统设置中搜索“环境变量”，在“用户变量”中新建
   `DEEPSEEK_API_KEY`。已经打开的 Codex Desktop 也能使用这个用户变量。
-- macOS / Linux：在启动 Codex 的 shell 或 secret manager 中设置
-  `DEEPSEEK_API_KEY`，再启动 Codex。
+- macOS：在“钥匙串访问”中新建“密码”项目，名称为
+  `com.example.codex.deepseek`，帐户为当前 macOS 用户名，密码为 DeepSeek API key。
+  安装后的 macOS Agent 会在每次请求 token 时通过系统钥匙串读取它，不需要
+  LaunchAgent 或 `launchctl setenv` 注入。
+- Linux：在启动 Codex 的 shell 或 secret manager 中设置 `DEEPSEEK_API_KEY`，
+  再启动 Codex。
 
-不知道怎么设置时，可以让 Codex 只解释你当前系统的环境变量设置方法，但不要把
-key 本身交给它。安全细节见 [SECURITY.md](SECURITY.md)。
+不知道怎么设置时，可以让 Codex 只解释你当前系统的密钥存储方式，但不要把 key
+本身交给它。安全细节见 [SECURITY.md](SECURITY.md)。
 
 ### 2. 把这一段复制给 Codex
 
@@ -82,7 +86,8 @@ CLI。
 - **看不到 `v4_flash_worker`：** 先新开任务；仍看不到再重启 Codex 一次。
 - **child 说没有收到任务：** 通常是 Hook 未信任、当前任务早于 Hook 安装，或者
   Hook 没有加载。检查 `/hooks` 后再新开任务，不要改用 inherited turns。
-- **提示缺少 `DEEPSEEK_API_KEY`：** 只检查环境变量是否存在，不要把 key 贴进聊天。
+- **提示缺少密钥：** macOS 检查钥匙串项目名称和帐户；Windows/Linux 只检查
+  `DEEPSEEK_API_KEY` 是否存在。不要把 key 贴进聊天。
 - **安装 Agent 要你切换全局 provider、启动另一套 CLI 或安装 MCP：** 停止；那不是
   本仓库的安装路径。
 
@@ -104,7 +109,8 @@ CLI。
 - 凭据、plaintext 本地状态和 DeepSeek 数据边界：[SECURITY.md](SECURITY.md)
 
 Windows Desktop 路径已经 live-pass；Python 3 协议在 Windows 和 Linux/WSL 通过。
-macOS 使用同一 POSIX 实现但尚无实机基线，欢迎实际 macOS 用户提交 Issue 或 PR。
+macOS 使用同一 POSIX Hook 实现，钥匙串 Agent 模板已有结构化验证；真实 macOS
+provider smoke 仍欢迎实际用户提交 Issue 或 PR。
 
 ## 费用与关联声明
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,11 +2,11 @@
 
 ## API keys
 
-Never commit a DeepSeek API key, paste it into a prompt, include it in a screenshot, or store it as `experimental_bearer_token`. The repository templates reference only `DEEPSEEK_API_KEY`.
+Never commit a DeepSeek API key, paste it into a prompt, include it in a screenshot, or store it as `experimental_bearer_token`. The repository templates reference only platform secret identifiers such as `DEEPSEEK_API_KEY` or the macOS Keychain service name `com.example.codex.deepseek`, never a plaintext key.
 
 If a key has been exposed, revoke or rotate it in the DeepSeek console before doing anything else. Do not open a public issue containing the key, request headers, or an unredacted configuration dump.
 
-The portable template uses Codex's `env_key` provider setting. The Windows live-environment variant uses Codex's command-backed authentication to read `DEEPSEEK_API_KEY` from the current user's environment at request time. The command prints the token only to Codex's authentication channel; validation instructions must never print it to the task transcript.
+The Linux template uses Codex's `env_key` provider setting. The macOS variant uses Codex's command-backed authentication to read a generic password from the current user's Keychain item named `com.example.codex.deepseek`. The Windows live-environment variant uses command-backed authentication to read `DEEPSEEK_API_KEY` from the current user's environment at request time. These commands print the token only to Codex's authentication channel; validation instructions must never print it to the task transcript.
 
 ## Data boundary
 

--- a/agents/macos-keychain/v4-flash-worker.toml
+++ b/agents/macos-keychain/v4-flash-worker.toml
@@ -21,5 +21,25 @@ sandbox_mode = "read-only"
 name = "DeepSeek"
 base_url = "https://api.deepseek.com"
 wire_api = "responses"
-env_key = "DEEPSEEK_API_KEY"
-env_key_instructions = "On Linux, set DEEPSEEK_API_KEY outside Codex, then start a new Codex process. Never paste the key into a prompt or commit it to a file."
+
+# This macOS variant reads the current user's Keychain item when each request
+# needs a token. Store the key as a generic password with service
+# "com.example.codex.deepseek" and account equal to the macOS username.
+[model_providers.deepseek.auth]
+command = "/bin/sh"
+args = [
+  "-c",
+  '''
+SERVICE="com.example.codex.deepseek"
+ACCOUNT="${USER:-$(/usr/bin/id -un)}"
+KEY="$(/usr/bin/security find-generic-password -s "$SERVICE" -a "$ACCOUNT" -w 2>/dev/null)" || {
+  /usr/bin/printf >&2 "DeepSeek API key not found in macOS Keychain service %s for account %s\n" "$SERVICE" "$ACCOUNT"
+  exit 2
+}
+[ -n "$KEY" ] || {
+  /usr/bin/printf >&2 "DeepSeek API key not found in macOS Keychain service %s for account %s\n" "$SERVICE" "$ACCOUNT"
+  exit 2
+}
+exec /usr/bin/printf "%s" "$KEY"
+''',
+]

--- a/docs/advanced.en.md
+++ b/docs/advanced.en.md
@@ -66,8 +66,9 @@ not establish that a new combination works.
 The Windows Desktop live smoke verified OpenAI parent → DeepSeek child → native
 callback. The PowerShell protocol test passes on Windows. The Python 3 protocol
 test passes on Windows and Linux/WSL, with Linux also covering
-`XDG_STATE_HOME`. macOS uses the same Python/POSIX implementation but is not yet
-part of the physical-host baseline; reproducible Issue or PR evidence is welcome.
+`XDG_STATE_HOME`. macOS uses the same Python/POSIX Hook implementation, and the
+Keychain agent template has structural validation; reproducible provider-smoke
+Issue or PR evidence from real macOS users is still welcome.
 
 Codex `0.145.0` marked configurable subagent models and reasoning effort in
 Multi-agent V2 stable. Custom agents, Hooks, and cross-provider transport still
@@ -77,7 +78,8 @@ evolve, so prefer a current stable release.
 
 | Path | Purpose |
 | --- | --- |
-| [`agents/v4-flash-worker.toml`](../agents/v4-flash-worker.toml) | macOS/Linux agent template |
+| [`agents/v4-flash-worker.toml`](../agents/v4-flash-worker.toml) | Linux environment-variable agent template |
+| [`agents/macos-keychain/v4-flash-worker.toml`](../agents/macos-keychain/v4-flash-worker.toml) | macOS Keychain agent template |
 | [`agents/windows-live-env/v4-flash-worker.toml`](../agents/windows-live-env/v4-flash-worker.toml) | Windows live user-environment template |
 | [`skills/use-v4-flash-worker/SKILL.md`](../skills/use-v4-flash-worker/SKILL.md) | Lazy-loaded selection, delivery, waiting, and failure protocol |
 | [`hooks/plaintext-handoff.ps1`](../hooks/plaintext-handoff.ps1) | Windows stage / Hook script |

--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -52,8 +52,9 @@ Hook matcher、脚本中的 role、skill、`AGENTS.md` 索引与 smoke oracle �
 
 Windows Desktop live smoke 已验证 OpenAI parent → DeepSeek child → native callback。
 PowerShell 协议测试在 Windows 通过；Python 3 协议测试在 Windows 和 Linux/WSL
-通过，Linux 还覆盖了 `XDG_STATE_HOME`。macOS 使用同一 Python/POSIX 实现，但
-尚未进入实机基线，欢迎通过 Issue 或 PR 补充可复现证据。
+通过，Linux 还覆盖了 `XDG_STATE_HOME`。macOS 使用同一 Python/POSIX Hook 实现，
+钥匙串 Agent 模板已有结构化验证；真实 macOS provider smoke 仍欢迎通过 Issue 或
+PR 补充可复现证据。
 
 Codex `0.145.0` 将可配置 subagent 模型与 reasoning effort 的 Multi-agent V2
 标记为稳定。custom agent、Hook 和跨 provider transport 仍在演进，优先使用当前
@@ -63,7 +64,8 @@ Codex `0.145.0` 将可配置 subagent 模型与 reasoning effort 的 Multi-agent
 
 | 路径 | 用途 |
 | --- | --- |
-| [`agents/v4-flash-worker.toml`](../agents/v4-flash-worker.toml) | macOS/Linux Agent 模板 |
+| [`agents/v4-flash-worker.toml`](../agents/v4-flash-worker.toml) | Linux 环境变量 Agent 模板 |
+| [`agents/macos-keychain/v4-flash-worker.toml`](../agents/macos-keychain/v4-flash-worker.toml) | macOS 钥匙串 Agent 模板 |
 | [`agents/windows-live-env/v4-flash-worker.toml`](../agents/windows-live-env/v4-flash-worker.toml) | Windows 实时读取用户环境变量的模板 |
 | [`skills/use-v4-flash-worker/SKILL.md`](../skills/use-v4-flash-worker/SKILL.md) | 按需加载的选择、交付、等待与失败协议 |
 | [`hooks/plaintext-handoff.ps1`](../hooks/plaintext-handoff.ps1) | Windows stage / Hook 脚本 |

--- a/hooks/plaintext_handoff.py
+++ b/hooks/plaintext_handoff.py
@@ -24,7 +24,8 @@ def state_root(value: Optional[str]) -> pathlib.Path:
         local_app_data = os.environ.get("LOCALAPPDATA")
         if local_app_data:
             return pathlib.Path(local_app_data) / "Codex" / "plaintext-subagent-handoff"
-    return pathlib.Path(os.environ.get("XDG_STATE_HOME", pathlib.Path.home() / ".local" / "state")) / "codex" / "plaintext-subagent-handoff"
+    state_home = pathlib.Path(os.environ.get("XDG_STATE_HOME", pathlib.Path.home() / ".local" / "state"))
+    return state_home.expanduser().resolve() / "codex" / "plaintext-subagent-handoff"
 
 
 def fail(message: str, code: int) -> None:

--- a/prompts/install-with-codex.md
+++ b/prompts/install-with-codex.md
@@ -25,8 +25,10 @@ Scope and invariants:
   and report the version limitation instead of silently changing the global
   configuration strategy.
 - Never ask me to paste an API key into chat, never print an existing key, and
-  never write a plaintext key into TOML. The only accepted secret name is the
-  environment variable DEEPSEEK_API_KEY.
+  never write a plaintext key into TOML. On macOS, the only accepted secret
+  source is the current user's Keychain generic-password item named
+  com.example.codex.deepseek. On Windows and Linux, the only accepted
+  environment variable is DEEPSEEK_API_KEY.
 - Do not make a paid provider call during installation.
 - Use Codex's native `SubagentStart` Hook mechanism for task delivery. Do not
   install a plugin, MCP adapter, wrapper process, daemon, direct HTTP/SDK call,
@@ -51,10 +53,13 @@ Procedure:
    authority already given by this prompt.
 3. Install exactly one agent file as
    <codex-home>/agents/v4-flash-worker.toml:
+   - On macOS, use agents/macos-keychain/v4-flash-worker.toml. This reads the
+     current user's Keychain item named com.example.codex.deepseek at request
+     time and does not require LaunchAgent or `launchctl setenv` injection.
    - On Windows, use agents/windows-live-env/v4-flash-worker.toml. This reads
      the user-scoped environment variable at request time and avoids requiring
      a running Desktop process to inherit a newly set key.
-   - On macOS or Linux, use agents/v4-flash-worker.toml.
+   - On Linux, use agents/v4-flash-worker.toml.
    Fetch the raw repository file or use the local checkout; do not recreate it
    from memory.
 4. Install `skills/use-v4-flash-worker` as
@@ -98,9 +103,13 @@ Procedure:
    deepseek-v4-flash, uses the Responses wire API, declares a 1000000-token
    model context window, defaults to read-only, contains no
    model_reasoning_effort, contains its own [model_providers.deepseek] definition,
-   and contains no plaintext credential. Confirm that the top-level config.toml
-   did not gain any main-model, main-provider, agent-registration, or DeepSeek
-   provider entries. Run the bundled skill-creator validator against the
+   and contains no plaintext credential. On macOS, confirm that authentication
+   uses command-backed `/usr/bin/security find-generic-password` against
+   com.example.codex.deepseek and does not use `env_key`. On Windows, confirm
+   that command-backed auth reads the user-scoped DEEPSEEK_API_KEY. On Linux,
+   confirm that `env_key` is DEEPSEEK_API_KEY. Confirm that the top-level
+   config.toml did not gain any main-model, main-provider, agent-registration,
+   or DeepSeek provider entries. Run the bundled skill-creator validator against the
    installed `use-v4-flash-worker` folder when that validator is available; if
    it is unavailable in this Codex build, parse the YAML files directly instead
    of installing another tool. Confirm that the frontmatter name and triggering
@@ -115,9 +124,12 @@ Procedure:
    Malformed or unknown pending state must remain fail closed. Remove only the
    verified temporary test/state material that this installation created; do
    not remove a pre-existing checkout.
-10. Check only whether DEEPSEEK_API_KEY is present; report a boolean, never its
-   value. On Windows check the user scope used by the installed auth command.
-   On other systems check the environment inherited by the Codex process.
+10. Check only whether the configured secret source is present; report a
+   boolean, never its value. On macOS, check the Keychain item named
+   com.example.codex.deepseek for the current macOS account; this may require a
+   normal Keychain access prompt, and the key must not be printed. On Windows,
+   check the user scope used by the installed auth command. On Linux, check the
+   environment inherited by the Codex process.
 11. Read back the installed configuration with any credential-like text
     redacted, then report changed paths, validation performed, whether the key
     is present, and that the Hook is not runnable until I review its exact

--- a/tests/test_agent_templates.py
+++ b/tests/test_agent_templates.py
@@ -1,0 +1,54 @@
+import pathlib
+import sys
+
+try:
+    import tomllib
+except ModuleNotFoundError:
+    print("SKIP: Python 3.11+ tomllib is unavailable")
+    raise SystemExit(0)
+
+
+ROOT = pathlib.Path(__file__).parents[1]
+
+
+def load_template(relative_path: str):
+    with (ROOT / relative_path).open("rb") as stream:
+        return tomllib.load(stream)
+
+
+def assert_base_agent(template):
+    assert template["name"] == "v4_flash_worker"
+    assert template["model_provider"] == "deepseek"
+    assert template["model"] == "deepseek-v4-flash"
+    assert template["model_context_window"] == 1000000
+    assert template["sandbox_mode"] == "read-only"
+    provider = template["model_providers"]["deepseek"]
+    assert provider["base_url"] == "https://api.deepseek.com"
+    assert provider["wire_api"] == "responses"
+    assert "experimental_bearer_token" not in str(template)
+    return provider
+
+
+def main() -> None:
+    linux_provider = assert_base_agent(load_template("agents/v4-flash-worker.toml"))
+    assert linux_provider["env_key"] == "DEEPSEEK_API_KEY"
+    assert "auth" not in linux_provider
+
+    macos_provider = assert_base_agent(load_template("agents/macos-keychain/v4-flash-worker.toml"))
+    assert "env_key" not in macos_provider
+    assert macos_provider["auth"]["command"] == "/bin/sh"
+    macos_auth_script = "\n".join(macos_provider["auth"]["args"])
+    assert "/usr/bin/security find-generic-password" in macos_auth_script
+    assert "com.example.codex.deepseek" in macos_auth_script
+    assert 'printf "%s" "$KEY"' in macos_auth_script
+
+    windows_provider = assert_base_agent(load_template("agents/windows-live-env/v4-flash-worker.toml"))
+    assert "env_key" not in windows_provider
+    assert windows_provider["auth"]["command"] == "powershell.exe"
+    assert "DEEPSEEK_API_KEY" in " ".join(windows_provider["auth"]["args"])
+
+    print("PASS: agent templates parse and use platform-specific secret sources")
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_plaintext_handoff.py
+++ b/tests/test_plaintext_handoff.py
@@ -100,7 +100,7 @@ def main() -> None:
         environment["CODEX_DEEPSEEK_HANDOFF_DIR"] = str(override)
         staged = run("stage", None, "Return exactly: OVERRIDE_STATE_ROOT", environment)
         assert staged.returncode == 0, staged.stderr
-        assert pathlib.Path(json.loads(staged.stdout)["pending_path"]).parent == override.resolve()
+        assert pathlib.Path(json.loads(staged.stdout)["pending_path"]).parent.resolve() == override.resolve()
         delivered = run("hook", None, hook_input("v4_flash_worker"), environment)
         assert delivered.returncode == 0, delivered.stderr
         assert "OVERRIDE_STATE_ROOT" in json.loads(delivered.stdout)["hookSpecificOutput"]["additionalContext"]
@@ -115,7 +115,7 @@ def main() -> None:
             staged = run("stage", None, "Return exactly: POSIX_XDG_STATE_ROOT", environment)
             assert staged.returncode == 0, staged.stderr
             expected = (xdg / "codex" / "plaintext-subagent-handoff").resolve()
-            assert pathlib.Path(json.loads(staged.stdout)["pending_path"]).parent == expected
+            assert pathlib.Path(json.loads(staged.stdout)["pending_path"]).parent.resolve() == expected
             delivered = run("hook", None, hook_input("v4_flash_worker"), environment)
             assert delivered.returncode == 0, delivered.stderr
             assert "POSIX_XDG_STATE_ROOT" in json.loads(delivered.stdout)["hookSpecificOutput"]["additionalContext"]


### PR DESCRIPTION
## Summary
- add a macOS Keychain-backed v4_flash_worker agent template
- update install docs, README, and security notes to use Keychain on macOS while preserving Windows/Linux secret flows
- normalize POSIX state path handling and add template parsing coverage

## Validation
- python3 tests/test_plaintext_handoff.py
- python3 tests/test_agent_templates.py
- python3 -m compileall hooks tests
- git diff --check

No paid DeepSeek smoke test was run.